### PR TITLE
add scripts for collect  information 

### DIFF
--- a/mysql/3161_Troubleshoot/show_engine_innodb_status.sh
+++ b/mysql/3161_Troubleshoot/show_engine_innodb_status.sh
@@ -1,4 +1,7 @@
 #/bin/bash
+## author: Jerry
+## email:  xumingyu528@gmail.com
+##
 
 
 

--- a/mysql/3161_Troubleshoot/show_engine_innodb_status.sh
+++ b/mysql/3161_Troubleshoot/show_engine_innodb_status.sh
@@ -1,0 +1,11 @@
+#/bin/bash
+
+
+
+while :;do
+
+  sleep 2;
+  mysql  -e 'show engine innodb status\G' >> show_engine_innodb_status.log
+
+
+done

--- a/mysql/3161_Troubleshoot/show_full_processlist.sh
+++ b/mysql/3161_Troubleshoot/show_full_processlist.sh
@@ -1,4 +1,8 @@
 #/bin/bash
+## author: Jerry
+## email:  xumingyu528@gmail.com
+##
+
 PASSWD=" "
 
 while :;do

--- a/mysql/3161_Troubleshoot/show_full_processlist.sh
+++ b/mysql/3161_Troubleshoot/show_full_processlist.sh
@@ -1,0 +1,17 @@
+#/bin/bash
+PASSWD=" "
+
+while :;do
+
+  sleep 1;
+  echo `date +%Y%m%d%H%M%S` >>  show_full_processlist.log
+  mysql $PASSWD -e 'SHOW FULL PROCESSLIST\G' | grep State: | sort | uniq -c  | sort -rn  >> show_full_processlist.log 2>/dev/null
+  echo ' ' >> show_full_processlist.log
+
+  echo `date +%Y%m%d%H%M%S` >>  detail_show_full_processlist.log
+  mysql $PASSWD -e 'SHOW FULL PROCESSLIST\G' >> detail_show_full_processlist.log 2>/dev/null
+  echo ' ' >> detail_show_full_processlist.log
+
+
+
+done


### PR DESCRIPTION
用于收集 MySQL processlist 输出信息，在脚本当前目录生成日志，脚本运行时间内持续收集，可以用于分析间歇性问题、收集数据库各线程状态。
scriptes for collection mysql infomation ,like processlist 、innodb status,  generates logs in the script's current directory, useful for analyzing intermittent issues and monitoring database thread status.